### PR TITLE
Issue 33

### DIFF
--- a/odufrn_downloader/modules/Dataset.py
+++ b/odufrn_downloader/modules/Dataset.py
@@ -111,10 +111,10 @@ class Dataset(Env, LevenshteinMixin):
             self.download_dataset(dataset, path, dictionary, years)
 
     def search_related_datasets(self, keyword: str) -> list:
-        """Baixa conjuntos de dados que possuam nomes
+        """Procura os conjuntos de dados que possuam nomes
         semelhantes à palavra recebida.
 
-        > Exemplo: download_related_datasets('discente')
+        > Exemplo: search_related_datasets('discente')
 
         Parâmetros
         ----------

--- a/odufrn_downloader/modules/Dataset.py
+++ b/odufrn_downloader/modules/Dataset.py
@@ -110,7 +110,7 @@ class Dataset(Env, LevenshteinMixin):
         for dataset in datasets:
             self.download_dataset(dataset, path, dictionary, years)
 
-    def download_related_datasets(self, keyword: str):
+    def search_related_datasets(self, keyword: str) -> list:
         """Baixa conjuntos de dados que possuam nomes
         semelhantes à palavra recebida.
 
@@ -125,12 +125,10 @@ class Dataset(Env, LevenshteinMixin):
         related = self.search_related(keyword, self.available_datasets)
 
         # Imprime exceção se não houver datasets similares
-        if len(related) == 0:
-            print("Não há nenhum conjunto de dados \
-                semelhante a \"{}\".".format(keyword))
-            return
+        if not len(related):
+            print("Não há nenhum conjunto de dados semelhante a \"{}\".".format(keyword))
 
-        self.download_datasets(related)
+        return related
         
     def download_all(self, path: str = os.getcwd(),
                           dictionary: bool = True, years: list = None):

--- a/odufrn_downloader/modules/Group.py
+++ b/odufrn_downloader/modules/Group.py
@@ -81,3 +81,23 @@ class Group(Dataset):
 
         for group in groups:
             self.download_group(group, path, dictionary)
+
+    def search_related_groups(self, keyword: str) -> list:
+        """Procura os grupos de conjuntos de dados que possuam nomes
+        semelhantes à palavra recebida.
+
+        > Exemplo: search_related_groups('pesquisa')
+
+        Parâmetros
+        ----------
+        keyword: str
+            palavra-chave com a qual será feita a busca
+        """
+        # Busca nomes de grupos semelhantes à palavra passada
+        related = self.search_related(keyword, self.available_groups)
+
+        # Imprime exceção se não houver grupos similares
+        if not len(related):
+            print("Não há nenhum grupo de conjunto de dados semelhante a \"{}\".".format(keyword))
+
+        return related


### PR DESCRIPTION
Resolve a _issue_ #33.

O fluxo agora é:
```python
# Para datasets
list_discentes = ufrn_data.search_related_datasets('discente')
ufrn_data.download_datasets(list_discentes)

# Para grupos
list_groups = ufrn_data.search_related_groups('pesquisa')
ufrn_data.download_groups(list_groups)
```

Dessa forma, o desenvolvedor tem mais poder sobre o que será baixado ou não. O método `download_related_datasets` na classe `Dataset` não existe mais.